### PR TITLE
Add psp for bitnami etcd backup/restore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 
 CHART_METADATA_IMAGE ?= artifactory.algol60.net/csm-docker/stable/chart-metadata
 YQ_IMAGE ?= artifactory.algol60.net/docker.io/mikefarah/yq:4
-HELM_IMAGE ?= artifactory.algol60.net/docker.io/alpine/helm:3.7.1
-HELM_UNITTEST_IMAGE ?= artifactory.algol60.net/docker.io/quintush/helm-unittest
-HELM_DOCS_IMAGE ?= artifactory.algol60.net/docker.io/jnorwood/helm-docs:v1.5.0
+HELM_IMAGE ?= artifactory.algol60.net/csm-docker/stable/docker.io/alpine/helm:3.9.4
+HELM_UNITTEST_IMAGE ?= artifactory.algol60.net/csm-docker/stable/docker.io/quintush/helm-unittest:latest
+HELM_DOCS_IMAGE ?= artifactory.algol60.net/csm-docker/stable/docker.io/jnorwood/helm-docs:v1.5.0
 
 all: lint dep-up test package
 
@@ -28,7 +28,7 @@ dep-up:
 test:
 	docker run --rm \
 		-v ${PWD}/charts:/apps \
-		${HELM_UNITTEST_IMAGE} -3 \
+		${HELM_UNITTEST_IMAGE} \
 		cray-psp
 
 package:

--- a/charts/cray-psp/Chart.yaml
+++ b/charts/cray-psp/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-psp
-version: 0.4.2
+version: 0.4.3
 description: Apply net-raw PSP
 keywords:
   - cray-psp

--- a/charts/cray-psp/templates/psp/cray-etcd-s3-sync.yaml
+++ b/charts/cray-psp/templates/psp/cray-etcd-s3-sync.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cray-etcd-s3-sync-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: restricted-transition-net-raw-psp
+subjects:
+- kind: ServiceAccount
+  name: etcd-backup-restore
+  namespace: services


### PR DESCRIPTION
## Summary and Scope

This is an initial checkin with basic backup/restore functionality working for bitnami chart's integration with S3.

## Issues and Related PRs

* Resolves [CASMPET-6182](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6182)

## Testing

```
ncn-m001-e2e75ea1:/home/bklein # kubectl exec -it -n services $(kubectl get po -n services -l 'app.kubernetes.io/name=cray-etcd-backup' -o jsonpath={.items[0].metadata.name}) -- /bin/sh -c 'restore_from_backup cray-bos db-2023-03-01_01-00'
Scaling etcd statefulset down to zero...
statefulset.apps/cray-bos-bitnami-etcd scaled
Waiting for statefulset spec update to be observed...
waiting for statefulset rolling update to complete 0 pods at revision cray-bos-bitnami-etcd-7977d754f8...
waiting for statefulset rolling update to complete 0 pods at revision cray-bos-bitnami-etcd-7977d754f8...
waiting for statefulset rolling update to complete 0 pods at revision cray-bos-bitnami-etcd-7977d754f8...
waiting for statefulset rolling update to complete 0 pods at revision cray-bos-bitnami-etcd-7977d754f8...
statefulset rolling update complete 0 pods at revision cray-bos-bitnami-etcd-7977d754f8...
statefulset.apps/cray-bos-bitnami-etcd env updated
Deleting existing PVC's...
persistentvolumeclaim "data-cray-bos-bitnami-etcd-0" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-1" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-2" deleted
Scaling etcd statefulset back up to three members...
statefulset.apps/cray-bos-bitnami-etcd scaled
Waiting for statefulset spec update to be observed...
Waiting for 3 pods to be ready...
Waiting for 2 pods to be ready...
Waiting for 1 pods to be ready...
statefulset rolling update complete 3 pods at revision cray-bos-bitnami-etcd-7b87987d9c...
statefulset.apps/cray-bos-bitnami-etcd env updated
```

```
ncn-m001-e2e75ea1:/home/bklein # kubectl exec -it -n services $(kubectl get po -n services -l 'app.kubernetes.io/name=cray-etcd-backup' -o jsonpath={.items[0].metadata.name}) -- /bin/sh -c 'list_backups cray-bos'
cray-bos/db-2023-02-27_23-00
cray-bos/db-2023-02-28_17-05
cray-bos/cray-bos_etcd_migration.snapshot.db
cray-bos/db-2023-02-24_00-00
cray-bos/db-2023-02-24_21-00
```

```
ncn-m001-e2e75ea1:/home/bklein # kubectl exec -it -n services $(kubectl get po -n services -l 'app.kubernetes.io/name=cray-etcd-backup' -o jsonpath={.items[0].metadata.name}) -- /bin/sh -c 'create_backup cray-bos brad-did-this-thrice'
Taking snapshot from cray-bos-bitnami-etcd-0...
Pushing newly created snapshot /snapshots/cray-bos-bitnami-etcd/db-2023-03-01_14-57 to S3 as brad-did-this-thrice for cray-bos
upload: snapshots/cray-bos-bitnami-etcd/db-2023-03-01_14-57 to s3://etcd-backup/cray-bos/brad-did-this-thrice
```

```
ncn-m001-e2e75ea1:/home/bklein # kubectl exec -it -n services $(kubectl get po -n services -l 'app.kubernetes.io/name=cray-etcd-backup' -o jsonpath={.items[0].metadata.name}) -- /bin/sh -c 'list_backups cray-bos' | grep thrice
cray-bos/brad-did-this-thrice
```

```
ncn-m001-e2e75ea1:/home/bklein # kubectl exec -it -n services $(kubectl get po -n services -l 'app.kubernetes.io/name=cray-etcd-backup' -o jsonpath={.items[0].metadata.name}) -- /bin/sh -c 'restore_from_backup cray-bos brad-did-this-thrice'
Downloading brad-did-this-thrice from S3 for cray-bos
download: s3://etcd-backup/cray-bos/brad-did-this-thrice to snapshots/cray-bos-bitnami-etcd/brad-did-this-thrice
Scaling etcd statefulset down to zero...
statefulset.apps/cray-bos-bitnami-etcd scaled
Waiting for statefulset spec update to be observed...
statefulset rolling update complete 0 pods at revision cray-bos-bitnami-etcd-7977d754f8...
statefulset.apps/cray-bos-bitnami-etcd env updated
Deleting existing PVC's...
persistentvolumeclaim "data-cray-bos-bitnami-etcd-0" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-1" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-2" deleted
Scaling etcd statefulset back up to three members...
statefulset.apps/cray-bos-bitnami-etcd scaled
waiting for statefulset rolling update to complete 0 pods at revision cray-bos-bitnami-etcd-547b4d6f46...
Waiting for 1 pods to be ready...
Waiting for 2 pods to be ready...
Waiting for 3 pods to be ready...
Waiting for 3 pods to be ready...
Waiting for 3 pods to be ready...
Waiting for 3 pods to be ready...
Waiting for 2 pods to be ready...
Waiting for 1 pods to be ready...
statefulset rolling update complete 3 pods at revision cray-bos-bitnami-etcd-547b4d6f46...
statefulset.apps/cray-bos-bitnami-etcd env updated
```

### Tested on:

  * Virtual Shasta

### Test description:

Lots of iterations

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable