### PR TITLE
Add NET_RAW for etcd-defrag jobs in services namespace

### DIFF
--- a/charts/cray-psp/Chart.yaml
+++ b/charts/cray-psp/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-psp
-version: 0.4.3
+version: 0.4.4
 description: Apply net-raw PSP
 keywords:
   - cray-psp

--- a/charts/cray-psp/templates/psp/cray-etcd-defrag.yaml
+++ b/charts/cray-psp/templates/psp/cray-etcd-defrag.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cray-etcd-defrag
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: restricted-transition-net-raw-psp
+subjects:
+- kind: ServiceAccount
+  name: etcd-defrag
+  namespace: services


### PR DESCRIPTION
### Summary and Scope

Update defrag jobs for new bitnami etcd statefulsets

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6375

### Testing

* ashton

```
pit:~/brad # kubectl logs -n services pod/kube-etcd-defrag-27973386-d5c5p
Running etcd defrag for: all
Skip defrag for: cray-hbtd-etcd
Skipping defrag for: cray-hbtd-etcd
Defragging cray-bos-bitnami-etcd-0
Defragging cray-bos-bitnami-etcd-1
Defragging cray-bos-bitnami-etcd-2
Completed
```

```
{"level":"info","ts":"2023-03-09T23:06:08.418Z","caller":"backend/backend.go:497","msg":"defragmenting","path":"/bitnami/etcd/data/member/snap/db","current-db-size-bytes":225280,"current-db-size":"225 kB","current-db-size-in-use-bytes":225280,"current-db-size-in-use":"225 kB"}
{"level":"info","ts":"2023-03-09T23:06:08.446Z","caller":"backend/backend.go:549","msg":"finished defragmenting directory","path":"/bitnami/etcd/data/member/snap/db","current-db-size-bytes-diff":-4096,"current-db-size-bytes":221184,"current-db-size":"221 kB","current-db-size-in-use-bytes-diff":-12288,"current-db-size-in-use-bytes":212992,"current-db-size-in-use":"213 kB","took":"70.172943ms"}
{"level":"info","ts":"2023-03-09T23:06:08.446Z","caller":"v3rpc/maintenance.go:96","msg":"finished defragment"}
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
